### PR TITLE
pyproject.toml: don't exclude qickdawg package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,4 +36,4 @@ Repository = "https://github.com/sandialabs/qick-dawg.git"
 version_variables = ["pyproject.toml:data.project.version"]
 
 [tool.setuptools.packages.find]
-exclude = ["qick*", "graphics*", "installation*", "jupyter_notebooks*"]
+exclude = ["qick", "graphics*", "installation*", "jupyter_notebooks*"]


### PR DESCRIPTION
"qick*" excludes the qickdawg package which should be installed.